### PR TITLE
fix: wrong concatenated item event name due to missing comma

### DIFF
--- a/src/game/client/tf/c_tf_gamestats.cpp
+++ b/src/game/client/tf/c_tf_gamestats.cpp
@@ -91,7 +91,7 @@ const char *g_ItemEventNames[] =
 	"item_used_tool",
 	"item_used_consumable",
 	"item_removed_attrib",
-	"item_changed_style"
+	"item_changed_style",
 
 	// NEW STORE EVENTS
 	"store2_entered",	// This gets written *in addition* to IE_STORE_ENTERED


### PR DESCRIPTION
# Description
Fixes an item event name being wrongfully concatenated due to missing comma in the const char list.

Before:
```
        "item_removed_attrib",
	"item_changed_style"

	// NEW STORE EVENTS
	"store2_entered",
```

Resulting in `"item_changed_stylestore2_entered"` being an entry.

Fix:
```
        "item_removed_attrib",
	"item_changed_style", // the comma

	// NEW STORE EVENTS
	"store2_entered",
```